### PR TITLE
fix: homepage style

### DIFF
--- a/public/scss/components/InstagramFeed.module.scss
+++ b/public/scss/components/InstagramFeed.module.scss
@@ -23,7 +23,7 @@
       @include fixedWidth(100%);
       background: rgba($color_white, 0.8);
       border: none;
-      text-align: left;
+      text-align: center;
       padding: 12px;
 
       @include typographyBuilder(secondary, 400, 14, 24);

--- a/public/scss/components/Product.module.scss
+++ b/public/scss/components/Product.module.scss
@@ -79,7 +79,6 @@
     padding: 3px 8px;
     display: table-cell;
     vertical-align: middle;
-    text-transform: uppercase;
 
     &__outofstock
     {


### PR DESCRIPTION
- center title instagram feed
- normal text for product tag